### PR TITLE
Fix bug when only the first match was highlighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.7] - Unreleased
 
 - Added language detection support for Ruby and JSX (@msaspence)
+- Fixed a bug when only the first match was highlighted (@bogdan0083)
 
 ## [0.0.6] - 2019-10-12
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -229,7 +229,7 @@ Total Files: ${Object.keys(files).length}\n`;
 
       // run through each match and update position to add 
       // hightlight for all matches
-      let index: number = 0;
+      let index = 0;
       matches.forEach(match => {
         const position = index === 0 ? index : index + match.length;
         index = result.content.indexOf(match, position);


### PR DESCRIPTION
Now all matches are highlighted:
<img src="https://image.prntscr.com/image/39iGWRICQsKXmA9a9N-bWg.png"/>

Works for queryRegex as well:
<img src="https://image.prntscr.com/image/_kO8eJecS9iwieSjN_GIhA.png" />